### PR TITLE
Add import for YamlDependencyNode

### DIFF
--- a/bsb_yaml/__init__.py
+++ b/bsb_yaml/__init__.py
@@ -2,4 +2,6 @@
 YAML parser for the BSB framework.
 """
 
+from .components import YamlDependencyNode
+
 __version__ = "0.0.0b4"

--- a/bsb_yaml/components.py
+++ b/bsb_yaml/components.py
@@ -1,5 +1,6 @@
 from bsb import config
 from bsb.storage import FileDependencyNode
+from .parser import YAMLParser
 
 
 @config.node
@@ -10,4 +11,4 @@ class YamlDependencyNode(FileDependencyNode):
 
     def load_object(self):
         content, encoding = self.file.get_content(check_store=hasattr(self, "scaffold"))
-        return config.get_parser("yaml").parse(content)[0]
+        return YAMLParser().parse(content)[0]


### PR DESCRIPTION
The `DependencyNode` classes are not automatically discovered by `bsb-core` as the `Storage` and `Parser` are.
I do not think it is a good idea for `bsb-core` to find and potentially import every `DependencyNode` available.
The `YamlDependencyNode` should therefore be exposed to let the user manually import it.
